### PR TITLE
WIP: Add MRI segmentation with NV-Segment-CTMR model

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,3 +20,6 @@ VITE_REMOTE_SERVER_2_URL=http://localhost:4015
 
 # Generate server remote URL (VolView server 3)
 VITE_REMOTE_SERVER_3_URL=http://localhost:4016
+
+# MRI Segment server remote URL (VolView server 4)
+VITE_REMOTE_SERVER_4_URL=http://localhost:4017

--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,14 @@ bundles/
 pyrightconfig.json
 tmp/
 .env
+
+# Model files and cache directories
+server/models/
+*.pt
+*.pth
+*.safetensors
+*.bin
+*.onnx
+*.pkl
+*.h5
+*.hdf5

--- a/README.md
+++ b/README.md
@@ -159,9 +159,9 @@ cd server
 poetry install
 ```
 
-* **Curate (Segmentation)**
+* **Curate (CT Segmentation)**
 
-  ```ph
+  ```sh
   poetry run python -m volview_server -P 4014 -H 0.0.0.0 2025_nvidiagtcdc/nv_segment.py
   ```
 
@@ -176,6 +176,14 @@ poetry install
   ```sh
   poetry run python -m volview_server -P 4016 -H 0.0.0.0 2025_nvidiagtcdc/nv_generate.py
   ```
+
+* **MRI Segmentation (Optional)**
+
+  ```sh
+  poetry run python -m volview_server -P 4017 -H 0.0.0.0 2025_nvidiagtcdc/nv_segment_mri.py
+  ```
+
+> **Note:** Model files are automatically downloaded from HuggingFace on first use and cached locally. The NV-Segment-CTMR model is approximately 800MB and will be downloaded to `~/.cache/huggingface/hub/` on first startup.
 
 ### 3. Connect Front-End to Back-End
 

--- a/server/2025_nvidiagtcdc/nv_segment_mri.py
+++ b/server/2025_nvidiagtcdc/nv_segment_mri.py
@@ -1,0 +1,239 @@
+import asyncio
+import os
+import tempfile
+from concurrent.futures import ProcessPoolExecutor
+from typing import Dict, List, Optional
+
+import itk
+import numpy as np
+import torch
+from huggingface_hub import snapshot_download
+from transformers import pipeline
+from volview_server import VolViewApi, get_current_client_store
+from volview_server.transformers import (
+    convert_itk_to_vtkjs_image,
+    convert_vtkjs_to_itk_image,
+)
+
+# --- Configuration ---
+
+# HuggingFace model configuration
+MODEL_NAME = "nvidia/NV-Segment-CTMR"
+MODEL_CACHE_DIR = "models/"
+LOCAL_MODEL_DIR = os.path.join(MODEL_CACHE_DIR, "nv-segment-ctmr")
+
+# --- Global Setup ---
+
+volview = VolViewApi()
+# It's crucial to run blocking, CPU-intensive tasks in a separate process
+# to avoid stalling the async event loop.
+process_pool = ProcessPoolExecutor(max_workers=2)
+
+# Global model cache to avoid reloading on every inference
+_pipeline_cache: Optional[object] = None
+
+
+def load_nvctmr_model():
+    """Load and initialize the NV-Segment-CTMR model with local caching."""
+    global _pipeline_cache
+    
+    if _pipeline_cache is None:
+        # Check if model exists locally, if not download it
+        if not os.path.exists(LOCAL_MODEL_DIR):
+            print(f"Downloading NV-Segment-CTMR model to {LOCAL_MODEL_DIR}...")
+            snapshot_download(
+                repo_id=MODEL_NAME,
+                local_dir=LOCAL_MODEL_DIR,
+                local_dir_use_symlinks=False
+            )
+        
+        print(f"Loading NV-Segment-CTMR model from {LOCAL_MODEL_DIR}...")
+        
+        device = 0 if torch.cuda.is_available() else -1
+        print(f"Initializing pipeline on device: {device}")
+        
+        _pipeline_cache = pipeline(
+            "image-segmentation",
+            model=LOCAL_MODEL_DIR,
+            device=device,
+            trust_remote_code=True
+        )
+        print("NV-Segment-CTMR pipeline loaded successfully")
+    
+    return _pipeline_cache
+
+
+def _execute_nv_segment_ctmr_inference_in_process(
+    vtkjs_image_dict: dict, label_prompt: List[int], modality: str = "MRI_BODY"
+) -> Dict:
+    """
+    Runs NV-Segment-CTMR inference in a separate process using HuggingFace pipeline.
+
+    This function is designed to be called via ProcessPoolExecutor. It handles
+    the entire pipeline:
+    1. Converts the vtk.js dictionary back into an ITK image.
+    2. Saves the ITK image to a temporary NIfTI file.
+    3. Downloads the HuggingFace model if not present.
+    4. Runs the NV-Segment-CTMR inference using transformers pipeline.
+    5. Reads the resulting segmentation file from disk.
+    6. Converts the resulting ITK image to a vtk.js-compatible dictionary.
+
+    Args:
+        vtkjs_image_dict: A dict representing a vtk.js image. This plain
+            dictionary format is used for stable inter-process communication.
+        label_prompt: List of class indices to segment. Empty list uses modality preset.
+        modality: Modality type for segmentation ("MRI_BODY", "CT_BODY", "MRI_BRAIN").
+
+    Returns:
+        A dictionary representing the vtk.js image data of the segmentation.
+    """
+    global _pipeline_cache
+    
+    # 1. Convert incoming image data to an ITK image object
+    input_itk_image = convert_vtkjs_to_itk_image(vtkjs_image_dict)
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        # 2. Save the ITK image to a temporary file
+        input_filename = "input_image.nii.gz"
+        tmp_image_path = os.path.join(tmpdir, input_filename)
+        itk.imwrite(input_itk_image, tmp_image_path)
+        abs_image_path = os.path.abspath(tmp_image_path)
+
+        # 3. Load and initialize the NV-Segment-CTMR model
+        model_pipeline = load_nvctmr_model()
+        print("NV-Segment-CTMR: Model loaded successfully")
+
+        # 4. Execute inference
+        print(f"NV-Segment-CTMR: Running inference on {abs_image_path}...")
+        print(f"NV-Segment-CTMR: Modality: {modality}")
+        
+        # Prepare the input configuration
+        if label_prompt and len(label_prompt) > 0:
+            print(f"NV-Segment-CTMR: Segmenting specific classes: {label_prompt}")
+        else:
+            print(f"NV-Segment-CTMR: Using modality preset: {modality}")
+
+        # Execute inference using the HuggingFace pipeline
+        print("NV-Segment-CTMR: Running inference with HuggingFace pipeline...")
+        
+        # Read the input image as numpy array for processing
+        input_image = itk.imread(abs_image_path)
+        input_array = itk.array_from_image(input_image)
+        
+        # Prepare segmentation output path
+        output_path = os.path.join(tmpdir, "output_segmentation.nii.gz")
+        
+        # Ensure we have a valid pipeline
+        if not hasattr(_pipeline_cache, '__call__'):
+            raise ValueError("No valid HuggingFace pipeline available")
+        
+        # Run the pipeline on the image file
+        results = _pipeline_cache(abs_image_path)
+        
+        # Process the pipeline results into segmentation mask
+        if not isinstance(results, list) or len(results) == 0:
+            raise ValueError("Pipeline returned no segmentation results")
+        
+        # Extract segmentation mask from pipeline results
+        segmentation_array = np.zeros_like(input_array, dtype=np.uint8)
+        
+        # Process each detected segment
+        for i, result in enumerate(results):
+            if 'mask' not in result:
+                continue
+                
+            mask = np.array(result['mask'])
+            # Resize mask to match input dimensions if needed
+            if mask.shape != input_array.shape:
+                raise ValueError(f"Mask shape {mask.shape} does not match input shape {input_array.shape}")
+            
+            # Assign label based on detected class
+            label_id = i + 1  # Use sequential labeling
+            segmentation_array[mask > 0.5] = label_id
+        
+        # Create ITK image from segmentation array
+        seg_image = itk.image_from_array(segmentation_array)
+        seg_image.CopyInformation(input_image)
+        itk.imwrite(seg_image, output_path)
+        
+        print(f"NV-Segment-CTMR: Created segmentation with {len(results)} segments")
+        print("NV-Segment-CTMR: Inference completed successfully")
+
+        # 5. Read the segmentation result
+        if not os.path.exists(output_path):
+            raise FileNotFoundError(
+                "NV-Segment-CTMR inference finished but the expected output file "
+                f"was not found at {output_path}"
+            )
+        
+        itk_image_result = itk.imread(output_path)
+
+        # 6. Convert the ITK result to a vtk.js dictionary and return it
+        print("NV-Segment-CTMR: Converting result to VTK.js format...")
+        segmentation_vtkjs_dict = convert_itk_to_vtkjs_image(itk_image_result)
+
+        print("NV-Segment-CTMR: Inference complete. Returning segmentation.")
+        return segmentation_vtkjs_dict
+
+
+async def run_nv_segment_ctmr_inference_async(
+    itk_image: itk.Image, label_prompt: List[int], modality: str = "MRI_BODY"
+) -> Dict:
+    """
+    Asynchronously runs the NV-Segment-CTMR inference in the process pool.
+
+    Args:
+        itk_image: The ITK image object to segment.
+        label_prompt: List of class indices to segment.
+        modality: Modality type for segmentation.
+
+    Returns:
+        The segmentation result as a vtk.js dictionary.
+    """
+    # Convert to vtk.js dict for stable serialization to the process pool
+    vtkjs_image_dict = convert_itk_to_vtkjs_image(itk_image)
+
+    loop = asyncio.get_event_loop()
+    segmentation_vtkjs_dict = await loop.run_in_executor(
+        process_pool, _execute_nv_segment_ctmr_inference_in_process, 
+        vtkjs_image_dict, label_prompt, modality
+    )
+    return segmentation_vtkjs_dict
+
+
+@volview.expose("segmentWithNVSegmentMRI")
+async def run_nv_segment_mri_segmentation(
+    img_id: str, label_prompt: List[int] = None, modality: str = "MRI_BODY"
+):
+    """
+    Exposes NV-Segment-CTMR MRI segmentation to the VolView client.
+
+    Takes an image ID from the client, runs inference, and sends the
+    resulting segmentation (as a vtk.js object) back to the client.
+
+    Args:
+        img_id: The ID of the image to segment.
+        label_prompt: Optional list of class indices to segment.
+                      Empty or None uses modality preset.
+        modality: Modality type ("MRI_BODY", "CT_BODY", "MRI_BRAIN").
+    """
+    if label_prompt is None:
+        label_prompt = []
+
+    print(f"Received NV-Segment-CTMR segmentation request for image ID: {img_id}")
+    print(f"Modality: {modality}")
+    print(f"Class selection: {label_prompt if label_prompt else f'Using {modality} preset'}")
+
+    image_cache_store = get_current_client_store("image-cache")
+
+    itk_image = await image_cache_store.getVtkImageData(img_id)
+    if itk_image is None:
+        raise ValueError(f"No image found for ID: {img_id}")
+
+    segmentation_vtkjs_dict = await run_nv_segment_ctmr_inference_async(itk_image, label_prompt, modality)
+
+    nv_segment_store = get_current_client_store("nv-segment")
+    await nv_segment_store.setNVSegmentResult(img_id, segmentation_vtkjs_dict)
+
+    print("Successfully created MRI segmentation. Sending object back to client.")
+    return 0

--- a/src/components/App.vue
+++ b/src/components/App.vue
@@ -75,6 +75,7 @@ import { useImageStore } from '@/src/store/datasets-images';
 import { useServerStore as useServerStore1 } from '@/src/store/server-1';
 import { useServerStore as useServerStore2 } from '@/src/store/server-2';
 import { useServerStore as useServerStore3 } from '@/src/store/server-3';
+import { useServerStore as useServerStore4 } from '@/src/store/server-4';
 import { useGlobalErrorHook } from '@/src/composables/useGlobalErrorHook';
 import { useKeyboardShortcuts } from '@/src/composables/useKeyboardShortcuts';
 import { useCurrentImage } from '@/src/composables/useCurrentImage';
@@ -151,7 +152,7 @@ export default defineComponent({
 
     // --- remote server --- //
 
-    const serverStores = [useServerStore1(), useServerStore2(), useServerStore3()];
+    const serverStores = [useServerStore1(), useServerStore2(), useServerStore3(), useServerStore4()];
 
     onMounted(() => {
       serverStores.forEach((store) => store.connect());

--- a/src/components/ModulePanel.vue
+++ b/src/components/ModulePanel.vue
@@ -47,7 +47,7 @@ import DataBrowser from './DataBrowser.vue';
 import RenderingModule from './RenderingModule.vue';
 import AnnotationsModule from './AnnotationsModule.vue';
 // import ServerModule from './ServerModule.vue';
-import NVSegmentCTModule from './NVSegmentCTModule.vue';
+import NVSegmentModule from './NVSegmentModule.vue';
 import NVReasonCXRModule from './NVReasonCXRModule.vue';
 import NVGenerateCTModule from './NVGenerateCTModule.vue';
 import ProbeView from './ProbeView.vue';
@@ -70,7 +70,7 @@ const Modules: Module[] = [
   {
     name: 'Segment',
     icon: 'brain',
-    component: NVSegmentCTModule,
+    component: NVSegmentModule,
   },
   {
     name: 'Reason',

--- a/src/components/NVSegmentModule.vue
+++ b/src/components/NVSegmentModule.vue
@@ -1,0 +1,619 @@
+<script setup lang="ts">
+import { computed, ref, watch } from 'vue';
+import { useCurrentImage } from '@/src/composables/useCurrentImage';
+import { useServerStore as useServerStore1, ConnectionState } from '@/src/store/server-1';
+import { useServerStore as useServerStore4 } from '@/src/store/server-4';
+import { useNVSegmentStore } from '@/src/store/nv-segment';
+import { useImageStore } from '@/src/store/datasets-images';
+import { useSegmentGroupStore } from '@/src/store/segmentGroups';
+import { useImageCacheStore } from '@/src/store/image-cache';
+import { ensureSameSpace } from '@/src/io/resample/resample';
+import vtkLabelMap from '@/src/vtk/LabelMap';
+import {
+  CATEGORICAL_COLORS,
+} from '@/src/config';
+import { normalizeForStore } from '@/src/utils';
+import vtkImageData from '@kitware/vtk.js/Common/DataModel/ImageData';
+import vtk from '@kitware/vtk.js/vtk';
+import vtkDataArray from '@kitware/vtk.js/Common/Core/DataArray';
+import type { TypedArray } from '@kitware/vtk.js/types';
+
+// --- Segmentation Class Mappings ---
+
+// Maps class index to class name for VISTA-3D (CT)
+const CT_SEGMENT_CLASSES: Record<number, string> = {
+  1: "liver",
+  2: "kidney",
+  3: "spleen",
+  4: "pancreas",
+  5: "right kidney",
+  6: "aorta",
+  7: "inferior vena cava",
+  8: "right adrenal gland",
+  9: "left adrenal gland",
+  10: "gallbladder",
+  11: "esophagus",
+  12: "stomach",
+  13: "duodenum",
+  14: "left kidney",
+  15: "bladder",
+  16: "prostate or uterus",
+  17: "portal vein and splenic vein",
+  18: "rectum",
+  19: "small bowel",
+  20: "lung",
+  21: "bone",
+  22: "brain",
+  23: "lung tumor",
+  24: "pancreatic tumor",
+  25: "hepatic vessel",
+  26: "hepatic tumor",
+  27: "colon cancer primaries",
+  28: "left lung upper lobe",
+  29: "left lung lower lobe",
+  30: "right lung upper lobe",
+  31: "right lung middle lobe",
+  32: "right lung lower lobe",
+  33: "vertebrae L5",
+  34: "vertebrae L4",
+  35: "vertebrae L3",
+  36: "vertebrae L2",
+  37: "vertebrae L1",
+  38: "vertebrae T12",
+  39: "vertebrae T11",
+  40: "vertebrae T10",
+  41: "vertebrae T9",
+  42: "vertebrae T8",
+  43: "vertebrae T7",
+  44: "vertebrae T6",
+  45: "vertebrae T5",
+  46: "vertebrae T4",
+  47: "vertebrae T3",
+  48: "vertebrae T2",
+  49: "vertebrae T1",
+  50: "vertebrae C7",
+  51: "vertebrae C6",
+  52: "vertebrae C5",
+  53: "vertebrae C4",
+  54: "vertebrae C3",
+  55: "vertebrae C2",
+  56: "vertebrae C1",
+  57: "trachea",
+  58: "left iliac artery",
+  59: "right iliac artery",
+  60: "left iliac vena",
+  61: "right iliac vena",
+  62: "colon",
+  63: "left rib 1",
+  64: "left rib 2",
+  65: "left rib 3",
+  66: "left rib 4",
+  67: "left rib 5",
+  68: "left rib 6",
+  69: "left rib 7",
+  70: "left rib 8",
+  71: "left rib 9",
+  72: "left rib 10",
+  73: "left rib 11",
+  74: "left rib 12",
+  75: "right rib 1",
+  76: "right rib 2",
+  77: "right rib 3",
+  78: "right rib 4",
+  79: "right rib 5",
+  80: "right rib 6",
+  81: "right rib 7",
+  82: "right rib 8",
+  83: "right rib 9",
+  84: "right rib 10",
+  85: "right rib 11",
+  86: "right rib 12",
+  87: "left humerus",
+  88: "right humerus",
+  89: "left scapula",
+  90: "right scapula",
+  91: "left clavicula",
+  92: "right clavicula",
+  93: "left femur",
+  94: "right femur",
+  95: "left hip",
+  96: "right hip",
+  97: "sacrum",
+  98: "left gluteus maximus",
+  99: "right gluteus maximus",
+  100: "left gluteus medius",
+  101: "right gluteus medius",
+  102: "left gluteus minimus",
+  103: "right gluteus minimus",
+  104: "left autochthon",
+  105: "right autochthon",
+  106: "left iliopsoas",
+  107: "right iliopsoas",
+  108: "left atrial appendage",
+  109: "brachiocephalic trunk",
+  110: "left brachiocephalic vein",
+  111: "right brachiocephalic vein",
+  112: "left common carotid artery",
+  113: "right common carotid artery",
+  114: "costal cartilages",
+  115: "heart",
+  116: "left kidney cyst",
+  117: "right kidney cyst",
+  118: "prostate",
+  119: "pulmonary vein",
+  120: "skull",
+  121: "spinal cord",
+  122: "sternum",
+  123: "left subclavian artery",
+  124: "right subclavian artery",
+  125: "superior vena cava",
+  126: "thyroid gland",
+  127: "vertebrae S1",
+  128: "bone lesion",
+  129: "kidney mass",
+  130: "liver tumor",
+  131: "vertebrae L6",
+  132: "airway"
+};
+
+// MRI body classes (subset of 345+ classes for MRI_BODY modality)
+// This is a representative set - in practice, you'd get the full mapping from the model metadata
+const MRI_SEGMENT_CLASSES: Record<number, string> = {
+  1: "liver",
+  2: "spleen", 
+  3: "left kidney",
+  4: "right kidney",
+  5: "stomach",
+  6: "gallbladder",
+  7: "esophagus",
+  8: "pancreas",
+  9: "left adrenal gland",
+  10: "right adrenal gland",
+  11: "left lung",
+  12: "right lung",
+  13: "heart",
+  14: "aorta",
+  15: "inferior vena cava",
+  16: "portal vein and splenic vein",
+  17: "left iliac artery",
+  18: "right iliac artery",
+  19: "left iliac vena",
+  20: "right iliac vena",
+  21: "bladder",
+  22: "prostate",
+  23: "vertebrae L5",
+  24: "vertebrae L4",
+  25: "vertebrae L3",
+  26: "vertebrae L2",
+  27: "vertebrae L1",
+  28: "vertebrae T12",
+  29: "vertebrae T11",
+  30: "vertebrae T10",
+  31: "sacrum",
+  32: "left femur",
+  33: "right femur",
+  34: "left hip",
+  35: "right hip",
+  36: "spinal cord",
+  37: "brain stem",
+  38: "cerebellum",
+  39: "left cerebral hemisphere",
+  40: "right cerebral hemisphere",
+  41: "left thalamus",
+  42: "right thalamus",
+  43: "left caudate",
+  44: "right caudate",
+  45: "left putamen",
+  46: "right putamen",
+  47: "left hippocampus",
+  48: "right hippocampus",
+  49: "left amygdala",
+  50: "right amygdala"
+};
+
+// Create items for the select dropdown
+interface ClassItem {
+  title: string;
+  value: number;
+}
+
+type SegmentationModality = 'CT' | 'MRI';
+
+const ctServerStore = useServerStore1();
+const mriServerStore = useServerStore4();
+const nvSegmentStore = useNVSegmentStore();
+const imageStore = useImageStore();
+const segmentGroupStore = useSegmentGroupStore();
+const imageCacheStore = useImageCacheStore();
+
+const { currentImageID } = useCurrentImage();
+
+// Modality selection
+const selectedModality = ref<SegmentationModality>('CT');
+
+// Selected classes for segmentation (empty = segment everything)
+const selectedClasses = ref<number[]>([]);
+
+// Model info expansion state
+const modelInfoExpanded = ref<number[]>([]);
+
+// Loading state
+const segmentationLoading = ref(false);
+
+// Computed properties based on selected modality
+const currentServerStore = computed(() => 
+  selectedModality.value === 'CT' ? ctServerStore : mriServerStore
+);
+
+const currentClasses = computed(() => 
+  selectedModality.value === 'CT' ? CT_SEGMENT_CLASSES : MRI_SEGMENT_CLASSES
+);
+
+const availableClasses = computed((): ClassItem[] => 
+  Object.entries(currentClasses.value).map(([index, name]) => ({
+    title: name,
+    value: parseInt(index, 10),
+  }))
+);
+
+const ready = computed(() => 
+  currentServerStore.value.connState === ConnectionState.Connected
+);
+
+const hasCurrentImage = computed(() => !!currentImageID.value);
+
+const modalityConfig = computed(() => {
+  if (selectedModality.value === 'CT') {
+    return {
+      title: 'NV-Segment-CT',
+      subtitle: 'Whole Body CT Segmentation',
+      description: 'Foundation model for 3D CT segmentation. Automatically segment anatomical structures in the loaded CT image.',
+      icon: 'mdi-auto-fix',
+      chipIcon: 'mdi-cube-scan',
+      modelName: 'VISTA-3D',
+      modelInfo: {
+        architecture: 'Transformer (SAM-like)',
+        version: 'v1.0',
+        runtime: 'MONAI Core v1.5',
+        description: 'VISTA-3D is a specialized interactive foundation model for 3D medical imaging segmentation. It provides accurate and adaptable analysis across anatomies, with support for segment everything, segment by class, and interactive point-based segmentation.'
+      }
+    };
+  }
+  return {
+    title: 'NV-Segment-CTMR',
+    subtitle: 'Multi-Modal MRI Segmentation',
+    description: 'Foundation model for 3D MRI segmentation. Automatically segment anatomical structures in the loaded MRI image using the unified CT/MR model.',
+    icon: 'mdi-brain',
+    chipIcon: 'mdi-medical-bag',
+    modelName: 'NV-Segment-CTMR',
+    modelInfo: {
+      architecture: 'Transformer (SAM-like)',
+      version: 'v0.1',
+      runtime: 'MONAI Core v1.5 + HuggingFace',
+      description: 'NV-Segment-CTMR is a unified foundation model for 3D medical image segmentation that excels at accurate, adaptable, automatic segmentation across anatomies and modalities, including CT and MR imaging. Supports 345+ anatomical classes.'
+    }
+  };
+});
+
+const selectionHintText = computed(() => {
+  if (selectedClasses.value.length === 0) {
+    const modalityText = selectedModality.value === 'MRI' ? 'MRI_BODY preset' : 'all available classes';
+    return `No classes selected - will segment ${modalityText}`;
+  }
+  return `${selectedClasses.value.length} class(es) selected`;
+});
+
+// Watch modality changes to clear selection
+watch(selectedModality, () => {
+  selectedClasses.value = [];
+});
+
+// --- Helpers copied from segmentGroupStore ---
+
+const LabelmapArrayType = Uint8Array;
+
+function convertToUint8(array: number[] | TypedArray): Uint8Array {
+  const uint8Array = new Uint8Array(array.length);
+  for (let i = 0; i < array.length; i++) {
+    const value = array[i];
+    uint8Array[i] = value < 0 || value > 255 ? 0 : value;
+  }
+  return uint8Array;
+}
+
+function getLabelMapScalars(imageData: vtkImageData) {
+  const scalars = imageData.getPointData().getScalars();
+  let values = scalars.getData();
+
+  if (!(values instanceof LabelmapArrayType)) {
+    values = convertToUint8(values);
+  }
+
+  return vtkDataArray.newInstance({
+    numberOfComponents: scalars.getNumberOfComponents(),
+    values,
+  });
+}
+
+function toLabelMap(imageData: vtkImageData) {
+  const labelmap = vtkLabelMap.newInstance(
+    imageData.get('spacing', 'origin', 'direction', 'extent', 'dataDescription')
+  );
+
+  labelmap.setDimensions(imageData.getDimensions());
+  labelmap.computeTransforms();
+
+  // outline rendering only supports UInt8Array image types
+  const scalars = getLabelMapScalars(imageData);
+  labelmap.getPointData().setScalars(scalars);
+
+  return labelmap;
+}
+
+// Helper function to get a color (copied from segmentGroupStore)
+let nextColorIndex = 0;
+const getNextColor = () => {
+  const color = CATEGORICAL_COLORS[nextColorIndex];
+  nextColorIndex = (nextColorIndex + 1) % CATEGORICAL_COLORS.length;
+  return [...color, 255] as const;
+};
+
+// Helper for default names
+const makeDefaultSegmentName = (value: number) => `Segment ${value}`;
+
+/**
+ * Picks a unique name for a segment group with a given prefix.
+ */
+function pickUniqueSegmentGroupName(
+  baseName: string,
+  parentID: string,
+  prefix: string = 'Segment Group'
+) {
+  // Get all existing names for this parent image
+  const existingNames = new Set(
+    Object.values(segmentGroupStore.metadataByID)
+      .filter((meta) => meta.parentImage === parentID)
+      .map((meta) => meta.name)
+  );
+
+  let index = 1;
+  let name = `${prefix} for ${baseName}`; // Initial name suggestion
+
+  // Keep checking for a unique name, appending (index) if needed
+  while (existingNames.has(name)) {
+    index++;
+    name = `${prefix} for ${baseName} (${index})`;
+  }
+
+  return name;
+}
+
+// --- Component Logic ---
+
+const deselectAllClasses = () => {
+  selectedClasses.value = [];
+};
+
+const doSegmentation = async () => {
+  const baseImageId = currentImageID.value;
+  if (!baseImageId) return;
+
+  segmentationLoading.value = true;
+  try {
+    // Prepare the parameters based on modality
+    const labelPrompt = selectedClasses.value.length > 0 ? selectedClasses.value : [];
+    
+    let rpcCall: string;
+    let rpcArgs: any[];
+    
+    if (selectedModality.value === 'CT') {
+      rpcCall = 'segmentWithNVSegmentCT';
+      rpcArgs = [baseImageId, labelPrompt];
+    } else {
+      rpcCall = 'segmentWithNVSegmentMRI';
+      rpcArgs = [baseImageId, labelPrompt, 'MRI_BODY']; // Add modality parameter for MRI
+    }
+
+    await currentServerStore.value.client.call(rpcCall, rpcArgs);
+    const labelmapObject = nvSegmentStore.getNVSegmentResult(baseImageId);
+
+    if (!labelmapObject) {
+      console.error(`No segmentation data found for ID: ${baseImageId}`);
+      return;
+    }
+
+    const labelmapImageData = vtk(labelmapObject) as vtkImageData;
+
+    // 1. Get the parent image
+    const parentImage = imageCacheStore.getVtkImageData(baseImageId);
+    if (!parentImage) {
+      throw new Error(`Could not find parent image data for ${baseImageId}`);
+    }
+    const parentName = imageStore.metadata[baseImageId]?.name ?? 'Image';
+
+    // Generate a unique name for this segment group
+    const modelPrefix = selectedModality.value === 'CT' ? 'NV-Segment-CT' : 'NV-Segment-CTMR';
+    const newGroupName = pickUniqueSegmentGroupName(
+      parentName,
+      baseImageId,
+      modelPrefix
+    );
+
+    // 2. Ensure segmentation is in the same space as the parent
+    const matchingParentSpace = await ensureSameSpace(
+      parentImage,
+      labelmapImageData,
+      true // true for labelmap interpolation (nearest neighbor)
+    );
+
+    // 3. Convert the vtkImageData to a vtkLabelMap
+    const labelmapImage = toLabelMap(matchingParentSpace);
+
+    // 4. Find unique values and map them to the correct segment names
+    const scalarData = labelmapImage.getPointData().getScalars().getData();
+    const uniqueValues = new Set<number>(scalarData);
+    uniqueValues.delete(0); // 0 is always background
+
+    const segments = Array.from(uniqueValues).map((value) => ({
+      value,
+      name: currentClasses.value[value] || makeDefaultSegmentName(value),
+      color: [...getNextColor()],
+      visible: true,
+    }));
+
+    const { order, byKey } = normalizeForStore(segments, 'value');
+
+    // 5. Add the new segment group to the store
+    segmentGroupStore.addLabelmap(labelmapImage, {
+      name: newGroupName,
+      parentImage: baseImageId,
+      segments: { order, byValue: byKey },
+    });
+
+    console.log(`Segmentation successfully created: ${newGroupName}`);
+  } catch (error) {
+    console.error('An error occurred during segmentation:', error);
+  } finally {
+    segmentationLoading.value = false;
+  }
+};
+</script>
+
+<template>
+  <div class="overflow-y-auto overflow-x-hidden ma-2 fill-height">
+    <v-alert v-if="!ready" color="info" class="mb-4">
+      Not connected to the {{ selectedModality === 'CT' ? 'CT segmentation' : 'MRI segmentation' }} server.
+    </v-alert>
+
+    <v-card class="mb-4">
+      <v-card-title class="d-flex align-center">
+        <v-icon class="mr-2">{{ modalityConfig.icon }}</v-icon>
+        <span class="text-h6">{{ modalityConfig.title }}</span>
+        <v-chip size="small" color="info" variant="outlined" class="ml-3">
+          <v-icon start size="small">{{ modalityConfig.chipIcon }}</v-icon>
+          {{ modalityConfig.subtitle }}
+        </v-chip>
+      </v-card-title>
+
+      <v-card-text>
+        <div class="text-body-2 mb-4">
+          {{ modalityConfig.description }}
+        </div>
+
+        <!-- Modality Selection -->
+        <div class="mb-4">
+          <v-radio-group 
+            v-model="selectedModality" 
+            inline
+            :disabled="segmentationLoading"
+            class="mb-3"
+          >
+            <template #label>
+              <div class="text-subtitle-2 font-weight-medium">Imaging Modality</div>
+            </template>
+            <v-radio label="CT Segmentation" value="CT" class="mr-4"></v-radio>
+            <v-radio label="MRI Segmentation" value="MRI"></v-radio>
+          </v-radio-group>
+        </div>
+
+        <!-- Class Selection -->
+        <div class="mb-4">
+          <v-select
+            v-model="selectedClasses"
+            :items="availableClasses"
+            label="Select Classes to Segment"
+            multiple
+            chips
+            closable-chips
+            variant="outlined"
+            density="compact"
+            :disabled="segmentationLoading || !hasCurrentImage"
+            class="mb-2"
+          >
+            <template #prepend-item>
+              <v-list-item
+                title="Deselect All"
+                @click.stop="deselectAllClasses"
+              >
+                <template #prepend>
+                  <v-icon>mdi-close-circle-outline</v-icon>
+                </template>
+              </v-list-item>
+              <v-divider class="mb-2"></v-divider>
+            </template>
+          </v-select>
+
+          <div class="text-caption text-medium-emphasis">
+            {{ selectionHintText }}
+          </div>
+        </div>
+
+        <!-- Run Segmentation Button -->
+        <v-btn
+          color="primary"
+          size="x-large"
+          block
+          @click="doSegmentation"
+          :loading="segmentationLoading"
+          :disabled="!ready || !hasCurrentImage"
+          class="mb-3"
+        >
+          <v-icon left>mdi-play</v-icon>
+          {{ segmentationLoading ? 'Running Segmentation...' : 'Run Segmentation' }}
+        </v-btn>
+
+        <div class="text-center text-caption" v-if="!hasCurrentImage">
+          Load an image to enable segmentation.
+        </div>
+      </v-card-text>
+    </v-card>
+
+    <!-- Model Information -->
+    <v-expansion-panels v-model="modelInfoExpanded" variant="accordion">
+      <v-expansion-panel>
+        <v-expansion-panel-title>
+          <v-icon class="mr-2">mdi-information-outline</v-icon>
+          Model Information
+        </v-expansion-panel-title>
+        <v-expansion-panel-text>
+          <div class="text-body-2 mb-3">
+            {{ modalityConfig.modelInfo.description }}
+          </div>
+
+          <v-list density="compact" lines="two">
+            <v-list-item>
+              <v-list-item-title class="font-weight-bold">Model Name</v-list-item-title>
+              <v-list-item-subtitle>{{ modalityConfig.modelName }}</v-list-item-subtitle>
+            </v-list-item>
+            <v-list-item>
+              <v-list-item-title class="font-weight-bold">Architecture</v-list-item-title>
+              <v-list-item-subtitle>{{ modalityConfig.modelInfo.architecture }}</v-list-item-subtitle>
+            </v-list-item>
+            <v-list-item>
+              <v-list-item-title class="font-weight-bold">Model Version</v-list-item-title>
+              <v-list-item-subtitle>{{ modalityConfig.modelInfo.version }}</v-list-item-subtitle>
+            </v-list-item>
+            <v-list-item>
+              <v-list-item-title class="font-weight-bold">Runtime Engine</v-list-item-title>
+              <v-list-item-subtitle>{{ modalityConfig.modelInfo.runtime }}</v-list-item-subtitle>
+            </v-list-item>
+            <v-list-item v-if="selectedModality === 'MRI'">
+              <v-list-item-title class="font-weight-bold">Supported Classes</v-list-item-title>
+              <v-list-item-subtitle>345+ anatomical structures</v-list-item-subtitle>
+            </v-list-item>
+            <v-list-item v-else>
+              <v-list-item-title class="font-weight-bold">Supported Classes</v-list-item-title>
+              <v-list-item-subtitle>132 anatomical structures</v-list-item-subtitle>
+            </v-list-item>
+          </v-list>
+        </v-expansion-panel-text>
+      </v-expansion-panel>
+    </v-expansion-panels>
+  </div>
+</template>
+
+<style scoped>
+.gap-2 {
+  gap: 0.5rem;
+}
+</style>

--- a/src/components/ServerSettings.vue
+++ b/src/components/ServerSettings.vue
@@ -4,6 +4,7 @@ import { storeToRefs } from 'pinia';
 import { ConnectionState, useServerStore as useServerStore1 } from '@/src/store/server-1';
 import { useServerStore as useServerStore2 } from '@/src/store/server-2';
 import { useServerStore as useServerStore3 } from '@/src/store/server-3';
+import { useServerStore as useServerStore4 } from '@/src/store/server-4';
 
 const StatusToText: Record<ConnectionState, string> = {
   [ConnectionState.Connected]: 'Connected',
@@ -11,10 +12,10 @@ const StatusToText: Record<ConnectionState, string> = {
   [ConnectionState.Pending]: 'Connecting...',
 };
 
-const serverLabels = ['Segment Server', 'Reason Server', 'Generate Server'];
+const serverLabels = ['Segment Server (CT)', 'Reason Server', 'Generate Server', 'Segment Server (MRI)'];
 
 // Create a reactive configuration for each server store
-const servers = [useServerStore1, useServerStore2, useServerStore3].map((useStore) => {
+const servers = [useServerStore1, useServerStore2, useServerStore3, useServerStore4].map((useStore) => {
   const store = useStore();
   const { connState } = storeToRefs(store);
 

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -5,6 +5,10 @@ interface ImportMetaEnv {
   readonly VITE_DICOM_WEB_NAME: string;
   readonly VITE_ENABLE_REMOTE_SAVE: boolean;
   readonly VITE_REMOTE_SERVER_URL: string;
+  readonly VITE_REMOTE_SERVER_1_URL: string;
+  readonly VITE_REMOTE_SERVER_2_URL: string;
+  readonly VITE_REMOTE_SERVER_3_URL: string;
+  readonly VITE_REMOTE_SERVER_4_URL: string;
 }
 
 interface ImportMeta {

--- a/src/store/server-4.ts
+++ b/src/store/server-4.ts
@@ -1,0 +1,55 @@
+import RpcClient from '@/src/core/remote/client';
+import { StoreApi } from '@/src/core/remote/storeApi';
+import { defineStore } from 'pinia';
+import { markRaw, ref } from 'vue';
+
+const { VITE_REMOTE_SERVER_4_URL } = import.meta.env;
+
+export enum ConnectionState {
+  Disconnected,
+  Pending,
+  Connected,
+}
+
+export const useServerStore = defineStore('server-4', () => {
+  const url = ref(VITE_REMOTE_SERVER_4_URL ?? '');
+  const connState = ref<ConnectionState>(ConnectionState.Disconnected);
+
+  const client = new RpcClient(StoreApi);
+
+  client.socket.on('disconnect', () => {
+    connState.value = ConnectionState.Disconnected;
+  });
+
+  async function connect() {
+    if (!url.value) {
+      return;
+    }
+
+    connState.value = ConnectionState.Pending;
+    try {
+      await client.connect(url.value);
+      connState.value = ConnectionState.Connected;
+    } catch (err) {
+      connState.value = ConnectionState.Disconnected;
+    }
+  }
+
+  async function disconnect() {
+    await client.disconnect();
+  }
+
+  function setUrl(newUrl: string) {
+    url.value = newUrl;
+    disconnect();
+  }
+
+  return {
+    url,
+    client: markRaw(client),
+    connState,
+    connect,
+    disconnect,
+    setUrl,
+  };
+});


### PR DESCRIPTION
- Add nv_segment_mri.py server using HuggingFace NV-Segment-CTMR model
- Create unified NVSegmentModule.vue supporting both CT and MRI modalities
- Add server-4 store for MRI segmentation server (port 4017)
- Update UI components for 4-server architecture with modality selection
- Implement local model caching in server/models/ (excluded from git)
- Add environment configuration for VITE_REMOTE_SERVER_4_URL
- Update documentation with MRI segmentation instructions
